### PR TITLE
:sparkles: Front/feat/timetable

### DIFF
--- a/udong-frontend/app/ui/feature/shared/TimeTable.tsx
+++ b/udong-frontend/app/ui/feature/shared/TimeTable.tsx
@@ -112,7 +112,12 @@ export const TimeTable = (props: TimeTableProps) => {
             handler(e)
             setDragCellIdx(null)
         }
-        const mouseMoveHandler = handler
+
+        let timeout: ReturnType<typeof setTimeout> | null = null
+        const mouseMoveHandler = (e: Event) => {
+            if (timeout) {clearTimeout(timeout)}
+            timeout = setTimeout(() => handler(e), 100)
+        }
 
         document.body.addEventListener('mouseup', mouseUpHandler)
         document.body.addEventListener('mousemove', mouseMoveHandler)

--- a/udong-frontend/app/ui/feature/shared/TimeTable.tsx
+++ b/udong-frontend/app/ui/feature/shared/TimeTable.tsx
@@ -64,17 +64,20 @@ interface TimeTableProps {
     days: string[]
     startTime: number
     data: number[][]
-    setHover: (colIdx: number, rowIdx: number) => void
+    onHover: (idx: [number, number] | null) => void
 }
 
 export const TimeTable = (props: TimeTableProps) => {
-    const { days, startTime, data, setHover } = props
+    const { days, startTime, data, onHover } = props
 
     const maxFn = (arr: number[]) => arr.reduce((a, b) => Math.max(a, b), 0)
     const mxCnt = maxFn(data.map(colData => maxFn(colData)))
 
     return (
-        <HStack>
+        <HStack
+            width={64 * days.length}
+            onMouseLeave={() => onHover(null)}
+        >
             {
                 data.map((colData, colIdx) => (
                     <VStack key={colIdx}>
@@ -87,7 +90,7 @@ export const TimeTable = (props: TimeTableProps) => {
                                             key={rowIdx}
                                             borderBottomStyle='dashed'
                                             backgroundOpacity={cnt / mxCnt / 2}
-                                            onHover={() => setHover(colIdx, rowIdx)}
+                                            onHover={() => onHover([colIdx, rowIdx])}
                                         >
                                             {startTime + (rowIdx / 2)}
                                         </BodyCell>
@@ -95,7 +98,7 @@ export const TimeTable = (props: TimeTableProps) => {
                                         key={rowIdx}
                                         borderBottomStyle='solid'
                                         backgroundOpacity={cnt / mxCnt / 2}
-                                        onHover={() => setHover(colIdx, rowIdx)}
+                                        onHover={() => onHover([colIdx, rowIdx])}
                                     />
                             ))
                         }

--- a/udong-frontend/app/ui/feature/shared/TimeTable.tsx
+++ b/udong-frontend/app/ui/feature/shared/TimeTable.tsx
@@ -4,13 +4,16 @@ import { MouseEvent, useEffect, useRef, useState } from 'react'
 import { HStack, VStack } from '../../components/Stack'
 import { UdongColors } from '../../theme/ColorPalette'
 
+const CELL_WIDTH = 64
+const CELL_HEIGHT = 32
+
 export type CellIdx = {
     col: number
     row: number
 }
 
 const Cell = styled.div({
-    width: 64,
+    width: CELL_WIDTH,
     verticalAlign: 'middle',
     borderColor: UdongColors.GrayNormal,
     borderLeftWidth: 0.5,
@@ -23,7 +26,7 @@ const Cell = styled.div({
 })
 
 const HeaderCell = styled(Cell)({
-    height: 32,
+    height: CELL_HEIGHT,
     backgroundColor: UdongColors.SecondaryBright,
     borderTopWidth: 1,
     borderBottomWidth: 1,
@@ -55,7 +58,7 @@ const BodyCell = (props: ({
     return (
         <Cell
             style={{
-                height: 16,
+                height: CELL_HEIGHT / 2,
                 borderBottomWidth: 1,
                 borderBottomStyle,
                 fontSize: 10,
@@ -108,8 +111,8 @@ export const TimeTable = (props: TimeTableProps) => {
                 const startCellIdx = dragCellIdx
                 const rect = ref.current.getBoundingClientRect()
                 const endCellIdx = {
-                    col: Math.floor(((e as unknown as MouseEvent).clientX - rect.left) / 64),
-                    row: Math.floor(((e as unknown as MouseEvent).clientY - rect.top) / 16) - 2,
+                    col: Math.floor(((e as unknown as MouseEvent).clientX - rect.left) / CELL_WIDTH),
+                    row: Math.floor(((e as unknown as MouseEvent).clientY - rect.top) / (CELL_HEIGHT / 2)) - 2,
                 }
                 onDrag(startCellIdx, endCellIdx)
             }
@@ -136,7 +139,7 @@ export const TimeTable = (props: TimeTableProps) => {
 
     return (
         <HStack
-            width={64 * days.length}
+            width={CELL_WIDTH * days.length}
             onMouseLeave={() => onHover(null)}
             style={{ cursor: 'default' }}
             ref={ref}

--- a/udong-frontend/app/ui/feature/shared/TimeTable.tsx
+++ b/udong-frontend/app/ui/feature/shared/TimeTable.tsx
@@ -25,12 +25,13 @@ const HeaderCell = styled(Cell)({
 })
 
 const BodyCell = (props: ({
-    backgroundOpacity: number
+    backgroundOpacity?: number
+    selected?: boolean
     borderBottomStyle: 'solid' | 'dashed'
     onHover: () => void
     children?: ReactNode
 })) => {
-    const { backgroundOpacity, borderBottomStyle, children, onHover } = props
+    const { backgroundOpacity, borderBottomStyle, selected, children, onHover } = props
     return (
         <Cell
             style={{
@@ -51,8 +52,9 @@ const BodyCell = (props: ({
                     right: 0,
                     top: 0,
                     bottom: 0,
-                    backgroundColor: UdongColors.Primary,
-                    opacity: backgroundOpacity,
+                    backgroundColor: selected ? UdongColors.Secondary : UdongColors.Primary,
+                    opacity: selected ? 1 : backgroundOpacity,
+                    zIndex: 0,
                 }}
             />
             {children}
@@ -64,11 +66,12 @@ interface TimeTableProps {
     days: string[]
     startTime: number
     data: number[][]
+    selected: boolean[][]
     onHover: (idx: [number, number] | null) => void
 }
 
 export const TimeTable = (props: TimeTableProps) => {
-    const { days, startTime, data, onHover } = props
+    const { days, startTime, data, selected, onHover } = props
 
     const maxFn = (arr: number[]) => arr.reduce((a, b) => Math.max(a, b), 0)
     const mxCnt = maxFn(data.map(colData => maxFn(colData)))
@@ -84,22 +87,21 @@ export const TimeTable = (props: TimeTableProps) => {
                         <HeaderCell key={colIdx}>{days[colIdx]}</HeaderCell>
                         {
                             colData.map((cnt, rowIdx) => (
-                                rowIdx % 2 === 0
-                                    ? (
-                                        <BodyCell
-                                            key={rowIdx}
-                                            borderBottomStyle='dashed'
-                                            backgroundOpacity={cnt / mxCnt / 2}
-                                            onHover={() => onHover([colIdx, rowIdx])}
-                                        >
-                                            {startTime + (rowIdx / 2)}
-                                        </BodyCell>
-                                    ) : <BodyCell
-                                        key={rowIdx}
-                                        borderBottomStyle='solid'
-                                        backgroundOpacity={cnt / mxCnt / 2}
-                                        onHover={() => onHover([colIdx, rowIdx])}
-                                    />
+                                <BodyCell
+                                    key={rowIdx}
+                                    borderBottomStyle={rowIdx % 2 ? 'solid' : 'dashed'}
+                                    backgroundOpacity={cnt / mxCnt / 2}
+                                    onHover={() => onHover([colIdx, rowIdx])}
+                                    selected={selected[colIdx][rowIdx]}
+                                >
+                                    {
+                                        rowIdx % 2
+                                            ? null
+                                            : <p style={{ margin: 0, zIndex: 30, position: 'relative' }}>
+                                                {startTime + (rowIdx / 2)}
+                                            </p>
+                                    }
+                                </BodyCell>
                             ))
                         }
                     </VStack>

--- a/udong-frontend/app/ui/feature/shared/TimeTable.tsx
+++ b/udong-frontend/app/ui/feature/shared/TimeTable.tsx
@@ -119,9 +119,11 @@ export const TimeTable = (props: TimeTableProps) => {
             if(dragCellIdx && ref.current) {
                 const startCellIdx = dragCellIdx
                 const rect = ref.current.getBoundingClientRect()
+                const endCol = Math.floor(((e as unknown as MouseEvent).clientX - rect.left) / CELL_WIDTH)
+                const endRow = Math.floor(((e as unknown as MouseEvent).clientY - rect.top) / (CELL_HEIGHT / 2)) - 2
                 const endCellIdx = {
-                    col: Math.floor(((e as unknown as MouseEvent).clientX - rect.left) / CELL_WIDTH),
-                    row: Math.floor(((e as unknown as MouseEvent).clientY - rect.top) / (CELL_HEIGHT / 2)) - 2,
+                    col: Math.min(Math.max(endCol, 0), data.length - 1),
+                    row: Math.min(Math.max(endRow, 0), data[0].length - 1),
                 }
                 onDrag(startCellIdx, endCellIdx)
             }

--- a/udong-frontend/app/ui/feature/shared/TimeTable.tsx
+++ b/udong-frontend/app/ui/feature/shared/TimeTable.tsx
@@ -17,9 +17,7 @@ const Cell = styled.div({
     verticalAlign: 'middle',
     borderColor: UdongColors.GrayNormal,
     borderStyle: 'solid',
-    borderLeftWidth: 0,
-    borderBottomWidth: 1,
-    borderRightWidth: 1,
+    borderWidth: 0.5,
     userSelect: 'none',
     WebkitUserSelect: 'none',
     cursor: 'default',
@@ -28,36 +26,37 @@ const Cell = styled.div({
 const HeaderCell = styled(Cell)({
     height: CELL_HEIGHT,
     backgroundColor: UdongColors.SecondaryBright,
-    borderTopWidth: 1,
     textAlign: 'center',
     lineHeight: 2,
 })
 
 const CellBg = styled.div({
     position: 'absolute',
-    left: 0,
-    right: 0,
+    left: -0.5,
+    right: -0.5,
     top: -0.5,
     bottom: -0.5,
+    borderColor: UdongColors.GrayNormal,
+    borderStyle: 'solid',
+    borderWidth: 0.5,
 })
 
 const BodyCell = (props: ({
     backgroundColor: string
     backgroundOpacity: number
-    borderBottomStyle: 'solid' | 'dashed'
+    isUpper: boolean
     onHover?: () => void
     onClick?: () => void
     onMouseDown?: (e: MouseEvent<HTMLDivElement>) => void
     text: string
     gray?: boolean
 })) => {
-    const { backgroundColor, backgroundOpacity, borderBottomStyle, text, gray, onHover, onClick, onMouseDown } = props
+    const { backgroundColor, backgroundOpacity, isUpper, text, gray, onHover, onClick, onMouseDown } = props
     return (
         <Cell
             style={{
                 height: CELL_HEIGHT / 2,
-                borderBottomStyle,
-                borderTopWidth: 0,
+                borderColor: 'transparent',
                 fontSize: 10,
                 paddingLeft: 2,
                 position: 'relative',
@@ -69,7 +68,15 @@ const BodyCell = (props: ({
         >
             <CellBg
                 style={{
+                    borderTopStyle: isUpper ? 'solid' : 'dashed',
+                    borderBottomStyle: isUpper ? 'dashed' : 'solid',
+                    zIndex: 30,
+                }}
+            />
+            <CellBg
+                style={{
                     backgroundColor,
+                    borderColor: 'transparent',
                     opacity: backgroundOpacity,
                     zIndex: 0,
                 }}
@@ -165,14 +172,13 @@ export const TimeTable = (props: TimeTableProps) => {
 
     return (
         <HStack
-            width={CELL_WIDTH * days.length}
+            width={(CELL_WIDTH * days.length) + 1}
             onMouseLeave={onHover && (() => onHover(null))}
             style={{
                 cursor: 'default',
                 borderColor: UdongColors.GrayNormal,
                 borderStyle: 'solid',
-                borderWidth: 0,
-                borderLeftWidth: 1,
+                borderWidth: 0.5,
                 ...style,
             }}
             ref={ref}
@@ -188,7 +194,7 @@ export const TimeTable = (props: TimeTableProps) => {
                                     : selected[col][row]
                                 return <BodyCell
                                     key={row}
-                                    borderBottomStyle={row % 2 ? 'solid' : 'dashed'}
+                                    isUpper={row % 2 == 0}
                                     backgroundColor={cellSelected ? (selectColor ?? UdongColors.Secondary) : UdongColors.Primary}
                                     backgroundOpacity={cellSelected ? 1 : cnt / mxCnt / 2}
                                     onHover={onHover && (() => onHover({ col, row }))}

--- a/udong-frontend/app/ui/feature/shared/TimeTable.tsx
+++ b/udong-frontend/app/ui/feature/shared/TimeTable.tsx
@@ -1,5 +1,74 @@
-export const TimeTable = () => {
-    return <h1>
-        유진이가 (원하면) 이름도 바꾸고 맘대로 채워주세요! 추가로 sub-component 만들어도 되구
-    </h1>
+import styled from '@emotion/styled'
+
+import { HStack, VStack } from '../../components/Stack'
+import { UdongColors } from '../../theme/ColorPalette'
+
+const Cell = styled.div({
+    width: 64,
+    verticalAlign: 'middle',
+    borderColor: UdongColors.GrayNormal,
+    borderLeftWidth: 0.5,
+    borderRightWidth: 0.5,
+    borderLeftStyle: 'solid',
+    borderRightStyle: 'solid',
+})
+
+const HeaderCell = styled(Cell)({
+    height: 32,
+    backgroundColor: UdongColors.SecondaryBright,
+    borderTopWidth: 1,
+    borderBottomWidth: 1,
+    borderStyle: 'solid',
+    textAlign: 'center',
+    lineHeight: 2,
+})
+
+const BodyCell = styled(Cell)<{
+    backgroundColor: string
+    borderBottomStyle: 'solid' | 'dashed'
+}>(props => ({
+    height: 16,
+    backgroundColor: props.backgroundColor,
+    borderBottomWidth: 1,
+    borderBottomStyle: props.borderBottomStyle,
+    fontSize: 10,
+    color: UdongColors.GrayNormal,
+    paddingLeft: 2,
+}))
+
+interface TimeTableProps {
+    days: string[]
+    startTime: number
+    data: number[][]
+}
+
+export const TimeTable = (props: TimeTableProps) => {
+    const { days, startTime, data } = props
+    return (
+        <HStack>
+            {
+                data.map((colData, colIdx) => (
+                    <VStack key={colIdx}>
+                        <HeaderCell key={colIdx}>{days[colIdx]}</HeaderCell>
+                        {
+                            colData.map((cnt, rowIdx) => (
+                                rowIdx % 2 == 0
+                                    ? (
+                                        <BodyCell
+                                            key={colIdx}
+                                            borderBottomStyle='dashed'
+                                        >
+                                            {startTime + (rowIdx / 2)}
+                                        </BodyCell>
+                                    ) : <BodyCell
+                                        key={colIdx}
+                                        borderBottomStyle='solid'
+                                    />
+                            ))
+                        }
+                    </VStack>
+                ))
+            }
+        </HStack>
+    )
 }

--- a/udong-frontend/app/ui/feature/shared/TimeTable.tsx
+++ b/udong-frontend/app/ui/feature/shared/TimeTable.tsx
@@ -45,9 +45,9 @@ const BodyCell = (props: ({
     backgroundColor: string
     backgroundOpacity: number
     borderBottomStyle: 'solid' | 'dashed'
-    onHover: () => void
-    onClick: () => void
-    onMouseDown: (e: MouseEvent<HTMLDivElement>) => void
+    onHover?: () => void
+    onClick?: () => void
+    onMouseDown?: (e: MouseEvent<HTMLDivElement>) => void
     text: string
     gray?: boolean
 })) => {
@@ -101,8 +101,8 @@ interface TimeTableProps {
     gray?: boolean[][]
     selectColor?: string
     style?: CSSProperties
-    onHover: (idx: CellIdx | null) => void
-    onClick: (idx: CellIdx) => void
+    onHover?: (idx: CellIdx | null) => void
+    onClick?: (idx: CellIdx) => void
     onDrag: (startIdx: CellIdx, endIdx: CellIdx) => void
 }
 
@@ -166,7 +166,7 @@ export const TimeTable = (props: TimeTableProps) => {
     return (
         <HStack
             width={CELL_WIDTH * days.length}
-            onMouseLeave={() => onHover(null)}
+            onMouseLeave={onHover && (() => onHover(null))}
             style={{
                 cursor: 'default',
                 borderColor: UdongColors.GrayNormal,
@@ -191,8 +191,8 @@ export const TimeTable = (props: TimeTableProps) => {
                                     borderBottomStyle={row % 2 ? 'solid' : 'dashed'}
                                     backgroundColor={cellSelected ? (selectColor ?? UdongColors.Secondary) : UdongColors.Primary}
                                     backgroundOpacity={cellSelected ? 1 : cnt / mxCnt / 2}
-                                    onHover={() => onHover({ col, row })}
-                                    onClick={() => onClick({ col, row })}
+                                    onHover={onHover && (() => onHover({ col, row }))}
+                                    onClick={onClick && (() => onClick({ col, row }))}
                                     onMouseDown={() => {
                                         setStartCellIdx({ col, row })
                                         setEndCellIdx({ col, row })

--- a/udong-frontend/app/ui/feature/shared/TimeTable.tsx
+++ b/udong-frontend/app/ui/feature/shared/TimeTable.tsx
@@ -136,8 +136,12 @@ export const TimeTable = (props: TimeTableProps) => {
 
         let timeout: ReturnType<typeof setTimeout> | null = null
         const mouseMoveHandler = (e: Event) => {
-            if (timeout) {clearTimeout(timeout)}
-            timeout = setTimeout(() => handler(e), 100)
+            if (!timeout) {
+                timeout = setTimeout(() => {
+                    handler(e)
+                    timeout = null
+                }, 100)
+            }
         }
 
         document.body.addEventListener('mouseup', mouseUpHandler)

--- a/udong-frontend/app/ui/feature/shared/TimeTable.tsx
+++ b/udong-frontend/app/ui/feature/shared/TimeTable.tsx
@@ -27,9 +27,10 @@ const HeaderCell = styled(Cell)({
 const BodyCell = (props: ({
     backgroundOpacity: number
     borderBottomStyle: 'solid' | 'dashed'
+    onHover: () => void
     children?: ReactNode
 })) => {
-    const { backgroundOpacity, borderBottomStyle, children } = props
+    const { backgroundOpacity, borderBottomStyle, children, onHover } = props
     return (
         <Cell
             style={{
@@ -41,6 +42,7 @@ const BodyCell = (props: ({
                 position: 'relative',
                 color: UdongColors.GrayNormal,
             }}
+            onMouseOver={onHover}
         >
             <div
                 style={{
@@ -62,13 +64,13 @@ interface TimeTableProps {
     days: string[]
     startTime: number
     data: number[][]
+    setHover: (colIdx: number, rowIdx: number) => void
 }
 
 export const TimeTable = (props: TimeTableProps) => {
-    const { days, startTime, data } = props
+    const { days, startTime, data, setHover } = props
 
     const maxFn = (arr: number[]) => arr.reduce((a, b) => Math.max(a, b), 0)
-
     const mxCnt = maxFn(data.map(colData => maxFn(colData)))
 
     return (
@@ -82,16 +84,18 @@ export const TimeTable = (props: TimeTableProps) => {
                                 rowIdx % 2 === 0
                                     ? (
                                         <BodyCell
-                                            key={colIdx}
+                                            key={rowIdx}
                                             borderBottomStyle='dashed'
                                             backgroundOpacity={cnt / mxCnt / 2}
+                                            onHover={() => setHover(colIdx, rowIdx)}
                                         >
                                             {startTime + (rowIdx / 2)}
                                         </BodyCell>
                                     ) : <BodyCell
-                                        key={colIdx}
+                                        key={rowIdx}
                                         borderBottomStyle='solid'
                                         backgroundOpacity={cnt / mxCnt / 2}
+                                        onHover={() => setHover(colIdx, rowIdx)}
                                     />
                             ))
                         }

--- a/udong-frontend/app/ui/feature/shared/TimeTable.tsx
+++ b/udong-frontend/app/ui/feature/shared/TimeTable.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled'
+import { ReactNode } from 'react'
 
 import { HStack, VStack } from '../../components/Stack'
 import { UdongColors } from '../../theme/ColorPalette'
@@ -23,18 +24,39 @@ const HeaderCell = styled(Cell)({
     lineHeight: 2,
 })
 
-const BodyCell = styled(Cell)<{
-    backgroundColor: string
+const BodyCell = (props: ({
+    backgroundOpacity: number
     borderBottomStyle: 'solid' | 'dashed'
-}>(props => ({
-    height: 16,
-    backgroundColor: props.backgroundColor,
-    borderBottomWidth: 1,
-    borderBottomStyle: props.borderBottomStyle,
-    fontSize: 10,
-    color: UdongColors.GrayNormal,
-    paddingLeft: 2,
-}))
+    children?: ReactNode
+})) => {
+    const { backgroundOpacity, borderBottomStyle, children } = props
+    return (
+        <Cell
+            style={{
+                height: 16,
+                borderBottomWidth: 1,
+                borderBottomStyle,
+                fontSize: 10,
+                paddingLeft: 2,
+                position: 'relative',
+                color: UdongColors.GrayNormal,
+            }}
+        >
+            <div
+                style={{
+                    position: 'absolute',
+                    left: 0,
+                    right: 0,
+                    top: 0,
+                    bottom: 0,
+                    backgroundColor: UdongColors.Primary,
+                    opacity: backgroundOpacity,
+                }}
+            />
+            {children}
+        </Cell>
+    )
+}
 
 interface TimeTableProps {
     days: string[]
@@ -44,6 +66,11 @@ interface TimeTableProps {
 
 export const TimeTable = (props: TimeTableProps) => {
     const { days, startTime, data } = props
+
+    const maxFn = (arr: number[]) => arr.reduce((a, b) => Math.max(a, b), 0)
+
+    const mxCnt = maxFn(data.map(colData => maxFn(colData)))
+
     return (
         <HStack>
             {
@@ -52,17 +79,19 @@ export const TimeTable = (props: TimeTableProps) => {
                         <HeaderCell key={colIdx}>{days[colIdx]}</HeaderCell>
                         {
                             colData.map((cnt, rowIdx) => (
-                                rowIdx % 2 == 0
+                                rowIdx % 2 === 0
                                     ? (
                                         <BodyCell
                                             key={colIdx}
                                             borderBottomStyle='dashed'
+                                            backgroundOpacity={cnt / mxCnt / 2}
                                         >
                                             {startTime + (rowIdx / 2)}
                                         </BodyCell>
                                     ) : <BodyCell
                                         key={colIdx}
                                         borderBottomStyle='solid'
+                                        backgroundOpacity={cnt / mxCnt / 2}
                                     />
                             ))
                         }

--- a/udong-frontend/app/ui/feature/shared/TimeTable.tsx
+++ b/udong-frontend/app/ui/feature/shared/TimeTable.tsx
@@ -39,7 +39,6 @@ const CellBg = styled.div({
     right: 0,
     top: -0.5,
     bottom: -0.5,
-    mixBlendMode: 'multiply',
 })
 
 const BodyCell = (props: ({
@@ -75,7 +74,18 @@ const BodyCell = (props: ({
                     zIndex: 0,
                 }}
             />
-            {gray && <CellBg style={{ backgroundColor: UdongColors.GrayBright, zIndex: 10 }} />}
+            {gray && <CellBg
+                style={{
+                    background: `repeating-linear-gradient(
+                        56deg,
+                        transparent,
+                        transparent 8px,
+                        ${UdongColors.GrayNormal} 8px,
+                        ${UdongColors.GrayNormal} 9px
+                    )`,
+                    zIndex: 10,
+                }}
+            />}
             <p style={{ margin: 0, zIndex: 30, position: 'relative', cursor: 'default' }} >
                 {text}
             </p>

--- a/udong-frontend/app/ui/feature/shared/TimeTable.tsx
+++ b/udong-frontend/app/ui/feature/shared/TimeTable.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { MouseEvent, useEffect, useRef, useState } from 'react'
+import { CSSProperties, MouseEvent, useEffect, useRef, useState } from 'react'
 
 import { HStack, VStack } from '../../components/Stack'
 import { UdongColors } from '../../theme/ColorPalette'
@@ -16,10 +16,10 @@ const Cell = styled.div({
     width: CELL_WIDTH,
     verticalAlign: 'middle',
     borderColor: UdongColors.GrayNormal,
-    borderLeftWidth: 0.5,
-    borderRightWidth: 0.5,
-    borderLeftStyle: 'solid',
-    borderRightStyle: 'solid',
+    borderStyle: 'solid',
+    borderLeftWidth: 0,
+    borderBottomWidth: 1,
+    borderRightWidth: 1,
     userSelect: 'none',
     WebkitUserSelect: 'none',
     cursor: 'default',
@@ -29,8 +29,6 @@ const HeaderCell = styled(Cell)({
     height: CELL_HEIGHT,
     backgroundColor: UdongColors.SecondaryBright,
     borderTopWidth: 1,
-    borderBottomWidth: 1,
-    borderStyle: 'solid',
     textAlign: 'center',
     lineHeight: 2,
 })
@@ -39,8 +37,8 @@ const CellBg = styled.div({
     position: 'absolute',
     left: 0,
     right: 0,
-    top: 0,
-    bottom: 0,
+    top: -0.5,
+    bottom: -0.5,
     mixBlendMode: 'multiply',
 })
 
@@ -59,8 +57,8 @@ const BodyCell = (props: ({
         <Cell
             style={{
                 height: CELL_HEIGHT / 2,
-                borderBottomWidth: 1,
                 borderBottomStyle,
+                borderTopWidth: 0,
                 fontSize: 10,
                 paddingLeft: 2,
                 position: 'relative',
@@ -91,13 +89,14 @@ interface TimeTableProps {
     data: number[][]
     selected: boolean[][]
     gray?: boolean[][]
+    style?: CSSProperties
     onHover: (idx: CellIdx | null) => void
     onClick: (idx: CellIdx) => void
     onDrag: (startIdx: CellIdx, endIdx: CellIdx) => void
 }
 
 export const TimeTable = (props: TimeTableProps) => {
-    const { days, startTime, data, selected, gray, onHover, onClick, onDrag } = props
+    const { days, startTime, data, selected, gray, style, onHover, onClick, onDrag } = props
 
     const [dragCellIdx, setDragCellIdx] = useState<CellIdx|null>(null)
     const ref = useRef<HTMLDivElement>(null)
@@ -141,7 +140,14 @@ export const TimeTable = (props: TimeTableProps) => {
         <HStack
             width={CELL_WIDTH * days.length}
             onMouseLeave={() => onHover(null)}
-            style={{ cursor: 'default' }}
+            style={{
+                cursor: 'default',
+                borderColor: UdongColors.GrayNormal,
+                borderStyle: 'solid',
+                borderWidth: 0,
+                borderLeftWidth: 1,
+                ...style,
+            }}
             ref={ref}
         >
             {

--- a/udong-frontend/app/ui/feature/shared/TimeTable.tsx
+++ b/udong-frontend/app/ui/feature/shared/TimeTable.tsx
@@ -32,6 +32,15 @@ const HeaderCell = styled(Cell)({
     lineHeight: 2,
 })
 
+const CellBg = styled.div({
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    top: 0,
+    bottom: 0,
+    mixBlendMode: 'multiply',
+})
+
 const BodyCell = (props: ({
     backgroundOpacity?: number
     selected?: boolean
@@ -40,8 +49,9 @@ const BodyCell = (props: ({
     onClick: () => void
     onMouseDown: (e: MouseEvent<HTMLDivElement>) => void
     text: string
+    gray?: boolean
 })) => {
-    const { backgroundOpacity, borderBottomStyle, text, selected, onHover, onClick, onMouseDown } = props
+    const { backgroundOpacity, borderBottomStyle, text, selected, gray, onHover, onClick, onMouseDown } = props
     return (
         <Cell
             style={{
@@ -57,18 +67,14 @@ const BodyCell = (props: ({
             onClick={onClick}
             onMouseDown={onMouseDown}
         >
-            <div
+            <CellBg
                 style={{
-                    position: 'absolute',
-                    left: 0,
-                    right: 0,
-                    top: 0,
-                    bottom: 0,
                     backgroundColor: selected ? UdongColors.Secondary : UdongColors.Primary,
                     opacity: selected ? 1 : backgroundOpacity,
                     zIndex: 0,
                 }}
             />
+            {gray && <CellBg style={{ backgroundColor: UdongColors.GrayBright, zIndex: 10 }} />}
             <p style={{ margin: 0, zIndex: 30, position: 'relative', cursor: 'default' }} >
                 {text}
             </p>
@@ -81,13 +87,14 @@ interface TimeTableProps {
     startTime: number
     data: number[][]
     selected: boolean[][]
+    gray?: boolean[][]
     onHover: (idx: CellIdx | null) => void
     onClick: (idx: CellIdx) => void
     onDrag: (startIdx: CellIdx, endIdx: CellIdx) => void
 }
 
 export const TimeTable = (props: TimeTableProps) => {
-    const { days, startTime, data, selected, onHover, onClick, onDrag } = props
+    const { days, startTime, data, selected, gray, onHover, onClick, onDrag } = props
 
     const [dragCellIdx, setDragCellIdx] = useState<CellIdx|null>(null)
     const ref = useRef<HTMLDivElement>(null)
@@ -148,6 +155,7 @@ export const TimeTable = (props: TimeTableProps) => {
                                     onClick={() => onClick({ col: colIdx, row: rowIdx })}
                                     onMouseDown={() => setDragCellIdx({ col: colIdx, row: rowIdx })}
                                     selected={selected[colIdx][rowIdx]}
+                                    gray={gray && gray[colIdx][rowIdx]}
                                     text={rowIdx % 2 ? '' : `${startTime + (rowIdx / 2)}`}
                                 />
                             ))

--- a/udong-frontend/app/ui/feature/shared/TimeTable.tsx
+++ b/udong-frontend/app/ui/feature/shared/TimeTable.tsx
@@ -142,21 +142,24 @@ export const TimeTable = (props: TimeTableProps) => {
             ref={ref}
         >
             {
-                data.map((colData, colIdx) => (
-                    <VStack key={colIdx}>
-                        <HeaderCell key={colIdx}>{days[colIdx]}</HeaderCell>
+                data.map((colData, col) => (
+                    <VStack key={col}>
+                        <HeaderCell key={col}>{days[col]}</HeaderCell>
                         {
-                            colData.map((cnt, rowIdx) => (
+                            colData.map((cnt, row) => (
                                 <BodyCell
-                                    key={rowIdx}
-                                    borderBottomStyle={rowIdx % 2 ? 'solid' : 'dashed'}
+                                    key={row}
+                                    borderBottomStyle={row % 2 ? 'solid' : 'dashed'}
                                     backgroundOpacity={cnt / mxCnt / 2}
-                                    onHover={() => onHover({ col: colIdx, row: rowIdx })}
-                                    onClick={() => onClick({ col: colIdx, row: rowIdx })}
-                                    onMouseDown={() => setDragCellIdx({ col: colIdx, row: rowIdx })}
-                                    selected={selected[colIdx][rowIdx]}
-                                    gray={gray && gray[colIdx][rowIdx]}
-                                    text={rowIdx % 2 ? '' : `${startTime + (rowIdx / 2)}`}
+                                    onHover={() => onHover({ col, row })}
+                                    onClick={() => onClick({ col, row })}
+                                    onMouseDown={() => {
+                                        setDragCellIdx({ col, row })
+                                        onDrag({ col, row }, { col, row })
+                                    }}
+                                    selected={selected[col][row]}
+                                    gray={gray && gray[col][row]}
+                                    text={row % 2 ? '' : `${startTime + (row / 2)}`}
                                 />
                             ))
                         }

--- a/udong-frontend/app/ui/feature/shared/TimeTable.tsx
+++ b/udong-frontend/app/ui/feature/shared/TimeTable.tsx
@@ -4,6 +4,11 @@ import { ReactNode } from 'react'
 import { HStack, VStack } from '../../components/Stack'
 import { UdongColors } from '../../theme/ColorPalette'
 
+export type CellIdx = {
+    col: number
+    row: number
+}
+
 const Cell = styled.div({
     width: 64,
     verticalAlign: 'middle',
@@ -29,6 +34,7 @@ const BodyCell = (props: ({
     selected?: boolean
     borderBottomStyle: 'solid' | 'dashed'
     onHover: () => void
+    onClick: () => void
     children?: ReactNode
 })) => {
     const { backgroundOpacity, borderBottomStyle, selected, children, onHover } = props
@@ -44,6 +50,8 @@ const BodyCell = (props: ({
                 color: UdongColors.GrayNormal,
             }}
             onMouseOver={onHover}
+            onMouseDown={console.log}
+            onMouseUp={console.log}
         >
             <div
                 style={{
@@ -67,7 +75,7 @@ interface TimeTableProps {
     startTime: number
     data: number[][]
     selected: boolean[][]
-    onHover: (idx: [number, number] | null) => void
+    onHover: (idx: CellIdx | null) => void
 }
 
 export const TimeTable = (props: TimeTableProps) => {
@@ -91,7 +99,7 @@ export const TimeTable = (props: TimeTableProps) => {
                                     key={rowIdx}
                                     borderBottomStyle={rowIdx % 2 ? 'solid' : 'dashed'}
                                     backgroundOpacity={cnt / mxCnt / 2}
-                                    onHover={() => onHover([colIdx, rowIdx])}
+                                    onHover={() => onHover({ col: colIdx, row: rowIdx })}
                                     selected={selected[colIdx][rowIdx]}
                                 >
                                     {

--- a/udong-frontend/app/ui/feature/shared/TimeTable.tsx
+++ b/udong-frontend/app/ui/feature/shared/TimeTable.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled'
-import { ReactNode } from 'react'
 
 import { HStack, VStack } from '../../components/Stack'
 import { UdongColors } from '../../theme/ColorPalette'
@@ -17,6 +16,9 @@ const Cell = styled.div({
     borderRightWidth: 0.5,
     borderLeftStyle: 'solid',
     borderRightStyle: 'solid',
+    userSelect: 'none',
+    WebkitUserSelect: 'none',
+    cursor: 'default',
 })
 
 const HeaderCell = styled(Cell)({
@@ -35,9 +37,9 @@ const BodyCell = (props: ({
     borderBottomStyle: 'solid' | 'dashed'
     onHover: () => void
     onClick: () => void
-    children?: ReactNode
+    text: string
 })) => {
-    const { backgroundOpacity, borderBottomStyle, selected, children, onHover } = props
+    const { backgroundOpacity, borderBottomStyle, text, selected, onHover, onClick } = props
     return (
         <Cell
             style={{
@@ -50,8 +52,7 @@ const BodyCell = (props: ({
                 color: UdongColors.GrayNormal,
             }}
             onMouseOver={onHover}
-            onMouseDown={console.log}
-            onMouseUp={console.log}
+            onClick={onClick}
         >
             <div
                 style={{
@@ -65,7 +66,9 @@ const BodyCell = (props: ({
                     zIndex: 0,
                 }}
             />
-            {children}
+            <p style={{ margin: 0, zIndex: 30, position: 'relative', cursor: 'default' }} >
+                {text}
+            </p>
         </Cell>
     )
 }
@@ -76,10 +79,11 @@ interface TimeTableProps {
     data: number[][]
     selected: boolean[][]
     onHover: (idx: CellIdx | null) => void
+    onClick: (idx: CellIdx) => void
 }
 
 export const TimeTable = (props: TimeTableProps) => {
-    const { days, startTime, data, selected, onHover } = props
+    const { days, startTime, data, selected, onHover, onClick } = props
 
     const maxFn = (arr: number[]) => arr.reduce((a, b) => Math.max(a, b), 0)
     const mxCnt = maxFn(data.map(colData => maxFn(colData)))
@@ -88,6 +92,7 @@ export const TimeTable = (props: TimeTableProps) => {
         <HStack
             width={64 * days.length}
             onMouseLeave={() => onHover(null)}
+            style={{ cursor: 'default' }}
         >
             {
                 data.map((colData, colIdx) => (
@@ -100,16 +105,10 @@ export const TimeTable = (props: TimeTableProps) => {
                                     borderBottomStyle={rowIdx % 2 ? 'solid' : 'dashed'}
                                     backgroundOpacity={cnt / mxCnt / 2}
                                     onHover={() => onHover({ col: colIdx, row: rowIdx })}
+                                    onClick={() => onClick({ col: colIdx, row: rowIdx })}
                                     selected={selected[colIdx][rowIdx]}
-                                >
-                                    {
-                                        rowIdx % 2
-                                            ? null
-                                            : <p style={{ margin: 0, zIndex: 30, position: 'relative' }}>
-                                                {startTime + (rowIdx / 2)}
-                                            </p>
-                                    }
-                                </BodyCell>
+                                    text={rowIdx % 2 ? '' : `${startTime + (rowIdx / 2)}`}
+                                />
                             ))
                         }
                     </VStack>

--- a/udong-frontend/app/ui/feature/shared/TimeTable.tsx
+++ b/udong-frontend/app/ui/feature/shared/TimeTable.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled'
+import { MouseEvent, useEffect, useRef, useState } from 'react'
 
 import { HStack, VStack } from '../../components/Stack'
 import { UdongColors } from '../../theme/ColorPalette'
@@ -37,9 +38,10 @@ const BodyCell = (props: ({
     borderBottomStyle: 'solid' | 'dashed'
     onHover: () => void
     onClick: () => void
+    onMouseDown: (e: MouseEvent<HTMLDivElement>) => void
     text: string
 })) => {
-    const { backgroundOpacity, borderBottomStyle, text, selected, onHover, onClick } = props
+    const { backgroundOpacity, borderBottomStyle, text, selected, onHover, onClick, onMouseDown } = props
     return (
         <Cell
             style={{
@@ -53,6 +55,7 @@ const BodyCell = (props: ({
             }}
             onMouseOver={onHover}
             onClick={onClick}
+            onMouseDown={onMouseDown}
         >
             <div
                 style={{
@@ -80,19 +83,51 @@ interface TimeTableProps {
     selected: boolean[][]
     onHover: (idx: CellIdx | null) => void
     onClick: (idx: CellIdx) => void
+    onDrag: (startIdx: CellIdx, endIdx: CellIdx) => void
 }
 
 export const TimeTable = (props: TimeTableProps) => {
-    const { days, startTime, data, selected, onHover, onClick } = props
+    const { days, startTime, data, selected, onHover, onClick, onDrag } = props
+
+    const [dragCellIdx, setDragCellIdx] = useState<CellIdx|null>(null)
+    const ref = useRef<HTMLDivElement>(null)
 
     const maxFn = (arr: number[]) => arr.reduce((a, b) => Math.max(a, b), 0)
     const mxCnt = maxFn(data.map(colData => maxFn(colData)))
+
+    useEffect(() => {
+        const handler = (e: Event) => {
+            if(dragCellIdx && ref.current) {
+                const startCellIdx = dragCellIdx
+                const rect = ref.current.getBoundingClientRect()
+                const endCellIdx = {
+                    col: Math.floor(((e as unknown as MouseEvent).clientX - rect.left) / 64),
+                    row: Math.floor(((e as unknown as MouseEvent).clientY - rect.top) / 16) - 2,
+                }
+                onDrag(startCellIdx, endCellIdx)
+            }
+        }
+
+        const mouseUpHandler = (e: Event) => {
+            handler(e)
+            setDragCellIdx(null)
+        }
+        const mouseMoveHandler = handler
+
+        document.body.addEventListener('mouseup', mouseUpHandler)
+        document.body.addEventListener('mousemove', mouseMoveHandler)
+        return () => {
+            document.body.removeEventListener('mouseup', mouseUpHandler)
+            document.body.removeEventListener('mousemove', mouseMoveHandler)
+        }
+    })
 
     return (
         <HStack
             width={64 * days.length}
             onMouseLeave={() => onHover(null)}
             style={{ cursor: 'default' }}
+            ref={ref}
         >
             {
                 data.map((colData, colIdx) => (
@@ -106,6 +141,7 @@ export const TimeTable = (props: TimeTableProps) => {
                                     backgroundOpacity={cnt / mxCnt / 2}
                                     onHover={() => onHover({ col: colIdx, row: rowIdx })}
                                     onClick={() => onClick({ col: colIdx, row: rowIdx })}
+                                    onMouseDown={() => setDragCellIdx({ col: colIdx, row: rowIdx })}
                                     selected={selected[colIdx][rowIdx]}
                                     text={rowIdx % 2 ? '' : `${startTime + (rowIdx / 2)}`}
                                 />

--- a/udong-frontend/pages/dummy/index.tsx
+++ b/udong-frontend/pages/dummy/index.tsx
@@ -7,6 +7,7 @@ import { UdongChip } from '../../app/ui/components/UdongChip'
 import { UdongModal } from '../../app/ui/components/UdongModal'
 import { UdongText } from '../../app/ui/components/UdongText'
 import { UdongTextField } from '../../app/ui/components/UdongTextField'
+import { TimeTable } from '../../app/ui/feature/shared/TimeTable'
 import { UdongColors } from '../../app/ui/theme/ColorPalette'
 
 export const DummyPage = () => {
@@ -85,6 +86,11 @@ export const DummyPage = () => {
         >
             <p>hell oworld</p>
         </UdongModal>
+        <TimeTable
+            days={['Mon', 'Tue', 'Wed', 'Thu', 'Fri']}
+            data={[[0, 0, 1, 1], [2, 2, 1, 0], [0, 0, 1, 1], [2, 1, 1, 0], [2, 1, 1, 0]]}
+            startTime={6}
+        />
     </VStack>
 }
 

--- a/udong-frontend/pages/dummy/index.tsx
+++ b/udong-frontend/pages/dummy/index.tsx
@@ -92,6 +92,13 @@ export const DummyPage = () => {
         <TimeTable
             days={['Mon', 'Tue', 'Wed', 'Thu', 'Fri']}
             data={[[0, 0, 1, 1], [2, 2, 1, 0], [0, 0, 1, 1], [2, 1, 1, 0], [2, 1, 1, 0]]}
+            selected={[
+                [false, false, false, false],
+                [false, false, false, false],
+                [false, false, true, false],
+                [false, false, false, false],
+                [false, false, false, false],
+            ]}
             startTime={6}
             onHover={setHoverIdx}
         />

--- a/udong-frontend/pages/dummy/index.tsx
+++ b/udong-frontend/pages/dummy/index.tsx
@@ -90,6 +90,7 @@ export const DummyPage = () => {
             days={['Mon', 'Tue', 'Wed', 'Thu', 'Fri']}
             data={[[0, 0, 1, 1], [2, 2, 1, 0], [0, 0, 1, 1], [2, 1, 1, 0], [2, 1, 1, 0]]}
             startTime={6}
+            setHover={console.log}
         />
     </VStack>
 }

--- a/udong-frontend/pages/dummy/index.tsx
+++ b/udong-frontend/pages/dummy/index.tsx
@@ -7,13 +7,13 @@ import { UdongChip } from '../../app/ui/components/UdongChip'
 import { UdongModal } from '../../app/ui/components/UdongModal'
 import { UdongText } from '../../app/ui/components/UdongText'
 import { UdongTextField } from '../../app/ui/components/UdongTextField'
-import { TimeTable } from '../../app/ui/feature/shared/TimeTable'
+import { CellIdx, TimeTable } from '../../app/ui/feature/shared/TimeTable'
 import { UdongColors } from '../../app/ui/theme/ColorPalette'
 
 export const DummyPage = () => {
     const [isOpen, setIsOpen] = useState(false)
 
-    const [hoverIdx, setHoverIdx] = useState<[number, number] | null>(null)
+    const [hoverIdx, setHoverIdx] = useState<CellIdx | null>(null)
     console.log(hoverIdx)
 
     return <VStack paddingHorizontal={32}>
@@ -101,6 +101,7 @@ export const DummyPage = () => {
             ]}
             startTime={6}
             onHover={setHoverIdx}
+            onClick={console.log}
         />
     </VStack>
 }

--- a/udong-frontend/pages/dummy/index.tsx
+++ b/udong-frontend/pages/dummy/index.tsx
@@ -102,6 +102,7 @@ export const DummyPage = () => {
             startTime={6}
             onHover={setHoverIdx}
             onClick={console.log}
+            onDrag={console.log}
         />
     </VStack>
 }

--- a/udong-frontend/pages/dummy/index.tsx
+++ b/udong-frontend/pages/dummy/index.tsx
@@ -99,6 +99,13 @@ export const DummyPage = () => {
                 [false, false, false, false],
                 [false, false, false, false],
             ]}
+            gray={[
+                [true, false, false, false],
+                [true, false, false, false],
+                [false, false, false, false],
+                [true, true, false, false],
+                [true, true, false, false],
+            ]}
             startTime={6}
             onHover={setHoverIdx}
             onClick={(idx) => console.log('click', idx)}

--- a/udong-frontend/pages/dummy/index.tsx
+++ b/udong-frontend/pages/dummy/index.tsx
@@ -13,6 +13,9 @@ import { UdongColors } from '../../app/ui/theme/ColorPalette'
 export const DummyPage = () => {
     const [isOpen, setIsOpen] = useState(false)
 
+    const [hoverIdx, setHoverIdx] = useState<[number, number] | null>(null)
+    console.log(hoverIdx)
+
     return <VStack paddingHorizontal={32}>
         <h1>This page introduces how to use the custom-made components.</h1>
 
@@ -90,7 +93,7 @@ export const DummyPage = () => {
             days={['Mon', 'Tue', 'Wed', 'Thu', 'Fri']}
             data={[[0, 0, 1, 1], [2, 2, 1, 0], [0, 0, 1, 1], [2, 1, 1, 0], [2, 1, 1, 0]]}
             startTime={6}
-            setHover={console.log}
+            onHover={setHoverIdx}
         />
     </VStack>
 }

--- a/udong-frontend/pages/dummy/index.tsx
+++ b/udong-frontend/pages/dummy/index.tsx
@@ -91,20 +91,26 @@ export const DummyPage = () => {
         </UdongModal>
         <TimeTable
             days={['Mon', 'Tue', 'Wed', 'Thu', 'Fri']}
-            data={[[0, 0, 1, 1], [2, 2, 1, 0], [0, 0, 1, 1], [2, 1, 1, 0], [2, 1, 1, 0]]}
+            data={[
+                [0, 0, 1, 1, 0, 1, 1, 1],
+                [2, 2, 1, 0, 0, 1, 1, 1],
+                [0, 0, 1, 1, 0, 1, 1, 1],
+                [2, 1, 1, 0, 0, 1, 1, 1],
+                [2, 1, 1, 0, 0, 1, 1, 1]
+            ]}
             selected={[
-                [false, false, false, false],
-                [false, false, false, false],
-                [false, false, true, false],
-                [false, false, false, false],
-                [false, false, false, false],
+                [false, false, false, false, false, false, false, false],
+                [false, false, false, false, false, false, false, false],
+                [false, false, true, false, false, false, false, false],
+                [false, false, false, false, false, false, false, false],
+                [false, false, false, false, false, false, false, false],
             ]}
             gray={[
-                [true, false, false, false],
-                [true, false, false, false],
-                [false, false, false, false],
-                [true, true, false, false],
-                [true, true, false, false],
+                [true, false, false, false, false, false, false, false],
+                [true, false, false, false, false, false, false, false],
+                [false, false, false, false, false, false, false, false],
+                [true, true, false, false, false, false, false, false],
+                [true, true, false, false, false, false, false, false],
             ]}
             startTime={6}
             style={{ marginTop: 20 }}

--- a/udong-frontend/pages/dummy/index.tsx
+++ b/udong-frontend/pages/dummy/index.tsx
@@ -96,7 +96,7 @@ export const DummyPage = () => {
                 [2, 2, 1, 0, 0, 1, 1, 1],
                 [0, 0, 1, 1, 0, 1, 1, 1],
                 [2, 1, 1, 0, 0, 1, 1, 1],
-                [2, 1, 1, 0, 0, 1, 1, 1]
+                [2, 1, 1, 0, 0, 1, 1, 1],
             ]}
             selected={[
                 [false, false, false, false, false, false, false, false],

--- a/udong-frontend/pages/dummy/index.tsx
+++ b/udong-frontend/pages/dummy/index.tsx
@@ -14,7 +14,7 @@ export const DummyPage = () => {
     const [isOpen, setIsOpen] = useState(false)
 
     const [hoverIdx, setHoverIdx] = useState<CellIdx | null>(null)
-    console.log(hoverIdx)
+    console.log('hover', hoverIdx)
 
     return <VStack paddingHorizontal={32}>
         <h1>This page introduces how to use the custom-made components.</h1>
@@ -101,8 +101,8 @@ export const DummyPage = () => {
             ]}
             startTime={6}
             onHover={setHoverIdx}
-            onClick={console.log}
-            onDrag={console.log}
+            onClick={(idx) => console.log('click', idx)}
+            onDrag={(s, e) => console.log('drag', s, e)}
         />
     </VStack>
 }

--- a/udong-frontend/pages/dummy/index.tsx
+++ b/udong-frontend/pages/dummy/index.tsx
@@ -107,6 +107,7 @@ export const DummyPage = () => {
                 [true, true, false, false],
             ]}
             startTime={6}
+            style={{ marginTop: 20 }}
             onHover={setHoverIdx}
             onClick={(idx) => console.log('click', idx)}
             onDrag={(s, e) => console.log('drag', s, e)}


### PR DESCRIPTION
- `<TimeTable/>` 구현
- `/dummy` 페이지에서 확인 가능
  - `onHover`, `onClick`, `onDrag`를 모두 console.log로 확인하도록 해놓음
- 선택된 칸 등의 정보는 모두 props로 받음