### PR TITLE
:bug: Fix jest settings in package.json

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -34,31 +34,35 @@ jobs:
         gem install coveralls-lcov
 
     - name: Install python dependencies
+      working-directory: ./udong-backend
       run: |
-        cd ./udong-backend
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install coveralls
 
     - name: Install node dependencies
+      working-directory: ./udong-frontend
       run: |
-        cd ./udong-frontend
         yarn install
         yarn global add coveralls
 
-    - name: Test
+    - name: Test frontend
+      working-directory: ./udong-frontend
       run: |
-        cd ./udong-frontend
-        node --trace-uncaught --trace-warnings node_modules/.bin/jest --coverage --watchAll=false --maxWorkers=16
+        node --trace-uncaught --trace-warnings node_modules/.bin/jest --coverage --watchAll=false
         echo "jest done"
         ls
-        ls -l coverage
         coveralls-lcov -v -n coverage/lcov.info > coverage.json
 
+        coveralls --merge=../../udong-frontend/coverage.json --service=github
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Test backend
+      working-directory: ./udong-backend
+      run: |
         cd ../udong-backend/udong
         coverage run --source='.' manage.py test
         coverage xml
-
-        coveralls --merge=../../udong-frontend/coverage.json --service=github
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Test
       run: |
         cd ./udong-frontend
-        node --trace-uncaught --trace-warnings node_modules/.bin/jest --coverage --watchAll=false --maxWorkers=4
+        node --trace-uncaught --trace-warnings node_modules/.bin/jest --coverage --watchAll=false --maxWorkers=16
         echo "jest done"
         ls
         ls -l coverage

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Test
       run: |
         cd ./udong-frontend
-        yarn test --coverage --watchAll=false
+        node --trace-uncaught --trace-warnings node_modules/.bin/jest --coverage --watchAll=false
         echo "jest done"
         ls
         ls -l coverage

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Test
       run: |
         cd ./udong-frontend
-        node --trace-uncaught --trace-warnings node_modules/.bin/jest --coverage --watchAll=false
+        node --trace-uncaught --trace-warnings node_modules/.bin/jest --coverage --watchAll=false --maxWorkers=2
         echo "jest done"
         ls
         ls -l coverage

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -50,6 +50,9 @@ jobs:
       run: |
         cd ./udong-frontend
         yarn test --coverage --watchAll=false
+        echo "jest done"
+        ls
+        ls -l coverage
         coveralls-lcov -v -n coverage/lcov.info > coverage.json
 
         cd ../udong-backend/udong

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Test
       run: |
         cd ./udong-frontend
-        node --trace-uncaught --trace-warnings node_modules/.bin/jest --coverage --watchAll=false --maxWorkers=2
+        node --trace-uncaught --trace-warnings node_modules/.bin/jest --coverage --watchAll=false --maxWorkers=4
         echo "jest done"
         ls
         ls -l coverage

--- a/udong-frontend/package.json
+++ b/udong-frontend/package.json
@@ -7,12 +7,13 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest --watch"
+    "test": "jest"
   },
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
     "@toast-ui/react-calendar": "^2.1.3",
+    "@types/jest": "^29.2.2",
     "@types/random-seed": "^0.3.3",
     "@typescript-eslint/eslint-plugin": "^5.41.0",
     "@typescript-eslint/parser": "^5.41.0",
@@ -26,13 +27,30 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-quill": "^2.0.0",
-    "react-spinners": "^0.13.6"
+    "react-spinners": "^0.13.6",
+    "ts-jest": "^29.0.3"
   },
   "devDependencies": {
-    "@types/node": "18.11.7",
+    "@types/node": "^18.11.9",
     "@types/react": "18.0.24",
     "@types/react-dom": "18.0.8",
     "jest": "^29.2.2",
     "typescript": "*"
+  },
+  "jest": {
+    "collectCoverageFrom": [
+      "app/**/*.{js,jsx,ts,tsx}"
+    ],
+    "collectCoverage": true,
+    "transform": {
+      "^.+\\.(ts|tsx|js|jsx)$": [
+        "ts-jest",
+        {
+          "tsconfig": {
+            "jsx": "react-jsx"
+          }
+        }
+      ]
+    }
   }
 }

--- a/udong-frontend/package.json
+++ b/udong-frontend/package.json
@@ -39,7 +39,8 @@
   },
   "jest": {
     "collectCoverageFrom": [
-      "app/**/*.{js,jsx,ts,tsx}"
+      "app/**/*.{js,jsx,ts,tsx}",
+      "pages/**/*.{js,jsx,ts,tsx}"
     ],
     "collectCoverage": true,
     "coverageDirectory": "./coverage",

--- a/udong-frontend/package.json
+++ b/udong-frontend/package.json
@@ -42,6 +42,7 @@
       "app/**/*.{js,jsx,ts,tsx}"
     ],
     "collectCoverage": true,
+    "coverageDirectory": "./coverage",
     "transform": {
       "^.+\\.(ts|tsx|js|jsx)$": [
         "ts-jest",

--- a/udong-frontend/pages/index.test.ts
+++ b/udong-frontend/pages/index.test.ts
@@ -1,1 +1,3 @@
 test('renders App.tsx', () => {}) // eslint-disable-line no-empty-function, @typescript-eslint/no-empty-function
+
+export {}

--- a/udong-frontend/yarn.lock
+++ b/udong-frontend/yarn.lock
@@ -921,6 +921,14 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
+"@types/jest@^29.2.2":
+  version "29.2.2"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.2.2.tgz#874e7dc6702fa6a3fe6107792aa98636dcc480b4"
+  integrity sha512-og1wAmdxKoS71K2ZwSVqWPX6OVn3ihZ6ZT2qvZvZQm90lJVDyXIjYcu4Khx2CNIeaFv12rOU/YObOsI3VOkzog==
+  dependencies:
+    expect "^29.0.0"
+    pretty-format "^29.0.0"
+
 "@types/json-schema@^7.0.9":
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
@@ -931,15 +939,10 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
-"@types/node@*":
+"@types/node@*", "@types/node@^18.11.9":
   version "18.11.9"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.9.tgz#02d013de7058cea16d36168ef2fc653464cfbad4"
   integrity sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==
-
-"@types/node@18.11.7":
-  version "18.11.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.7.tgz#8ccef136f240770c1379d50100796a6952f01f94"
-  integrity sha512-LhFTglglr63mNXUSRYD8A+ZAIu5sFqNJ4Y2fPuY7UlrySJH87rRRlhtVmMHplmfk5WkoJGmDjE9oiTfyX94CpQ==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -1366,6 +1369,13 @@ browserslist@^4.21.3:
     electron-to-chromium "^1.4.251"
     node-releases "^2.0.6"
     update-browserslist-db "^1.0.9"
+
+bs-logger@0.x:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
+  integrity sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==
+  dependencies:
+    fast-json-stable-stringify "2.x"
 
 bser@2.1.1:
   version "2.1.1"
@@ -2039,7 +2049,7 @@ exit@^0.1.2:
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
   integrity sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==
 
-expect@^29.2.2:
+expect@^29.0.0, expect@^29.2.2:
   version "29.2.2"
   resolved "https://registry.yarnpkg.com/expect/-/expect-29.2.2.tgz#ba2dd0d7e818727710324a6e7f13dd0e6d086106"
   integrity sha512-hE09QerxZ5wXiOhqkXy5d2G9ar+EqOyifnCXCpMNu+vZ6DG9TJ6CO2c2kPDSLqERTTWrO7OZj8EkYHQqSd78Yw==
@@ -2076,7 +2086,7 @@ fast-glob@^3.2.9:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
-fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -2934,7 +2944,7 @@ jest-snapshot@^29.2.2:
     pretty-format "^29.2.1"
     semver "^7.3.5"
 
-jest-util@^29.2.1:
+jest-util@^29.0.0, jest-util@^29.2.1:
   version "29.2.1"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.2.1.tgz#f26872ba0dc8cbefaba32c34f98935f6cf5fc747"
   integrity sha512-P5VWDj25r7kj7kl4pN2rG/RN2c1TLfYYYZYULnS/35nFDjBai+hBeo3MDrYZS7p6IoY3YHZnt2vq4L6mKnLk0g==
@@ -3146,6 +3156,11 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash.memoize@4.x:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+  integrity sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==
+
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
@@ -3176,6 +3191,11 @@ make-dir@^3.0.0:
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
   dependencies:
     semver "^6.0.0"
+
+make-error@1.x:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
 makeerror@1.0.12:
   version "1.0.12"
@@ -3560,7 +3580,7 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==
 
-pretty-format@^29.2.1:
+pretty-format@^29.0.0, pretty-format@^29.2.1:
   version "29.2.1"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.2.1.tgz#86e7748fe8bbc96a6a4e04fa99172630907a9611"
   integrity sha512-Y41Sa4aLCtKAXvwuIpTvcFBkyeYp2gdFWzXGA+ZNES3VwURIB165XO/z7CjETwzCCS53MjW/rLMyyqEnTtaOfA==
@@ -3794,17 +3814,17 @@ scheduler@^0.23.0:
   dependencies:
     loose-envify "^1.1.0"
 
-semver@^6.0.0, semver@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
-  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
-
-semver@^7.3.5, semver@^7.3.7:
+semver@7.x, semver@^7.3.5, semver@^7.3.7:
   version "7.3.8"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
   integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
   dependencies:
     lru-cache "^6.0.0"
+
+semver@^6.0.0, semver@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
+  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
 shebang-command@^2.0.0:
   version "2.0.0"
@@ -4043,6 +4063,20 @@ tr46@^3.0.0:
   integrity sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==
   dependencies:
     punycode "^2.1.1"
+
+ts-jest@^29.0.3:
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.0.3.tgz#63ea93c5401ab73595440733cefdba31fcf9cb77"
+  integrity sha512-Ibygvmuyq1qp/z3yTh9QTwVVAbFdDy/+4BtIQR2sp6baF2SJU/8CKK/hhnGIDY2L90Az2jIqTwZPnN2p+BweiQ==
+  dependencies:
+    bs-logger "0.x"
+    fast-json-stable-stringify "2.x"
+    jest-util "^29.0.0"
+    json5 "^2.2.1"
+    lodash.memoize "4.x"
+    make-error "1.x"
+    semver "7.x"
+    yargs-parser "^21.0.1"
 
 tsconfig-paths@^3.14.1:
   version "3.14.1"
@@ -4288,7 +4322,7 @@ yaml@^1.10.0:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
-yargs-parser@^21.1.1:
+yargs-parser@^21.0.1, yargs-parser@^21.1.1:
   version "21.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==


### PR DESCRIPTION
## 기존 문제 상황
- package.json에서 jest 설정을 안해줌
- coverage를 collect할 대상을 jest가 못 찾음
- 그래서 coveralls.yml github action이 돌아도 빈 coverage가 나옴
- coveralls에서 백엔드만 보임

## 해결
- package.json에서 jest 설정을 해줌
- 그런데 jest가 제대로 돌려면 tsconfig의 jsx 값이 "react-jsx"여야 함
- Next가 제대로 돌려면 이가 "preserve"여야 함
- 그래서 package.json에서 jest를 위한 tsconfig.jsx 값을 따로 설정해줌