### PR TITLE
:wrench: Update settings about cors, csrf

### DIFF
--- a/udong-backend/udong/udong/settings.py
+++ b/udong-backend/udong/udong/settings.py
@@ -20,6 +20,7 @@ env = environ.Env(
     SECRET_KEY=(str, "secret"),
     ALLOWED_HOSTS=(list, ["*"]),
     CORS_ALLOWED_ORIGINS=(list, []),
+    CSRF_TRUSTED_ORIGINS=(list, []),
 )
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -97,6 +98,14 @@ MIDDLEWARE = [
 ]
 
 CORS_ALLOWED_ORIGINS = env("CORS_ALLOWED_ORIGINS")
+CORS_ALLOW_CREDENTIALS = True
+
+CSRF_COOKIE_SECURE = True
+CSRF_TRUSTED_ORIGINS = env("CSRF_TRUSTED_ORIGINS")
+CSRF_COOKIE_SAMESITE = "None"
+
+SESSION_COOKIE_SECURE = True
+SESSION_COOKIE_SAMESITE = "None"
 
 ROOT_URLCONF = "udong.urls"
 

--- a/udong-frontend/app/infra/global.ts
+++ b/udong-frontend/app/infra/global.ts
@@ -6,4 +6,6 @@ const { publicRuntimeConfig } = getConfig()
 export const axiosConfig = axios.create({
     baseURL: publicRuntimeConfig.backendUrl,
     withCredentials: true,
+    xsrfCookieName: 'csrftoken',
+    xsrfHeaderName: 'X-CSRFTOKEN',
 })


### PR DESCRIPTION
CSRF 쿠키랑 세션 쿠키 관련 설정 수정했어요.

## 여정
- sessionid 쿠키가 오려면 SameSite가 None이어야 함
- session_cookie_domain을 ""나 "localhost"으로 하는 것도 시도해보았으나 안 먹힘
  - `.`을 2개 이상 포함해야된다는 규칙 위반이라 무시됨
- 근데 SameSite=None이려면 secure해야함
- 그래서 백엔드에 https를 달았음
- 그랬더니 프론트가 insecure하다고 안됨

## 결론
- 로컬 프론트는 로컬 백엔드랑 연결하자
  - 프론드 `.env`에서 `NEXT_PUBLIC_BASE_URL="http://localhost:8000"`
  - 백엔드 `.env`에는
    ```shell
    ALLOWED_HOSTS=localhost,127.0.0.1
    CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost,http://127.0.0.1:3000,http://127.0.0.1
    CSRF_TRUSTED_ORIGINS=http://localhost:3000,http://localhost,http://127.0.0.1:3000,http://127.0.0.1
    ```